### PR TITLE
Arreglado mensaje de "Infinity" al dividir entre 0

### DIFF
--- a/calculadora.js
+++ b/calculadora.js
@@ -240,7 +240,14 @@ function realizarOperacionDeFondo() {
       return parseFloat(valorAnterior) * parseFloat(valorActual);
       break;
     case 'division':
-      return parseFloat(valorAnterior) / parseFloat(valorActual);
+      var valor = parseFloat(valorAnterior) / parseFloat(valorActual);
+      if (valor == "Infinity") { // si se divide entre 0 
+        window.alert("No dividas entre 0!")
+        return 0;
+      }
+      else {
+        return valor; 
+      }
       break;
     case 'igual':
       actualizarPantalla('Esto no debería haber pasado nunca xD');


### PR DESCRIPTION
Cuando dividias entre 0 la calculadora escribía el mensaje de "Infinity" por defecto, esto lo arregla al darte una alerta de "no hacer eso" y poner el resultado en 0.